### PR TITLE
airdrop 100,000 instead of 1000 to localnet payer

### DIFF
--- a/src/solana_rpc_api.rs
+++ b/src/solana_rpc_api.rs
@@ -161,7 +161,7 @@ impl RpcConnection {
         runtime
             .0
             .rpc
-            .request_airdrop(&runtime.payer().pubkey(), 1000 * LAMPORTS_PER_SOL)?;
+            .request_airdrop(&runtime.payer().pubkey(), 100_000 * LAMPORTS_PER_SOL)?;
 
         Ok(runtime)
     }


### PR DESCRIPTION
somehow the margin tests are using over 1,000 sol. 10,000 was enough for them to pass. 100,000 should be plenty...