### PR TITLE
reduce default airdrop and expose airdrop in api

### DIFF
--- a/src/solana_rpc_api.rs
+++ b/src/solana_rpc_api.rs
@@ -163,10 +163,18 @@ impl RpcConnection {
         runtime
             .0
             .rpc
-            .request_airdrop(&runtime.payer().pubkey(), 100_000 * LAMPORTS_PER_SOL)
+            .request_airdrop(&runtime.payer().pubkey(), 1_000 * LAMPORTS_PER_SOL)
             .await?;
 
         Ok(runtime)
+    }
+
+    pub async fn request_airdrop(&self, sol: u64) -> Result<Signature> {
+        Ok(self
+            .0
+            .rpc
+            .request_airdrop(&self.payer().pubkey(), sol * LAMPORTS_PER_SOL)
+            .await?)
     }
 }
 


### PR DESCRIPTION
This change is necessary for https://github.com/jet-lab/jet-v2/pull/433

I've reduced the airdrop on init from 100,000 SOL to 1,000 SOL which is still quite large. Any scenarios that require more than 1,000 SOL can request an airdrop with the new public method.

The massive airdrop of 100,000 SOL causes problems on localnet if the rpc client is initialized repeatedly. After around 10-20 airdrops, the airdrop instruction itself results in an error indicating that there are not enough lamports. It appears to be drawing from some reserve of lamports inside the validator that runs dry. 